### PR TITLE
feat: basic path preserving cache

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,7 @@
+# Pins optional config ----
+#PINS_CACHE_DIR=.pins_cache
+#PINS_DATA_DIR=.pins_data
+
 # AWS S3 backend ----
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/docs/getting_started.Rmd
+++ b/docs/getting_started.Rmd
@@ -250,3 +250,7 @@ You can read this data by combining `pin_download()` with `read.csv()`[^1]:
 
 # pd.read_csv(fname)
 ```
+
+```{python}
+my_data.pin_download("penguins")
+```

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -586,11 +586,10 @@ class BoardManual(BaseBoard):
         # special case where we are using http protocol to fetch what may be
         # a file. here we need to create a stripped down form of metadata, since
         # a metadata file does not exist (and we can't pull files from a version dir).
-        if self.fs.protocol == "http" and not pin_name.rstrip().endswith("/"):
+        path_to_pin = self.construct_path([pin_name])
+        if self.fs.protocol == "http" and not path_to_pin.rstrip().endswith("/"):
             # create metadata, rather than read from a file
-            path_download = self.construct_path([pin_name])
-
-            return self.meta_factory.create_raw(path_download, type="file",)
+            return self.meta_factory.create_raw(path_to_pin, type="file",)
 
         path_meta = self.construct_path([pin_name, meta_name])
         f = self.fs.open(path_meta)
@@ -612,6 +611,12 @@ class BoardManual(BaseBoard):
 
         if self.board.strip() == "":
             return pin_path
+
+        if len(others):
+            # this is confusing, but R pins url board has a final "/" indicate that
+            # something is a pin version, rather than a single file. but since other
+            # boards forbid a final /, we need to strip it off to join elements
+            pin_path = pin_path.rstrip().rstrip("/")
 
         return super().construct_path([pin_path, *others])
 

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -45,9 +45,13 @@ class IFileSystem(Protocol):
 
 class BaseBoard:
     def __init__(
-        self, board: str, fs: IFileSystem, versioned=True, meta_factory=MetaFactory(),
+        self,
+        board: "str | Path",
+        fs: IFileSystem,
+        versioned=True,
+        meta_factory=MetaFactory(),
     ):
-        self.board = board
+        self.board = str(board)
         self.fs = fs
         self.meta_factory = meta_factory
 

--- a/pins/cache.py
+++ b/pins/cache.py
@@ -36,6 +36,13 @@ def touch_access_time(path, access_time: "float | None" = None):
     return access_time
 
 
+def protocol_to_string(protocol):
+    if isinstance(protocol, str):
+        return protocol
+
+    return protocol[0]
+
+
 class PinsCache(SimpleCacheFileSystem):
     protocol = "pinscache"
 
@@ -74,7 +81,8 @@ class PinsCache(SimpleCacheFileSystem):
 
                 # TODO: hacky to automatically tack on protocol here
                 # but this is what R pins boards do. Could make a bool arg?
-                full_prefix = "_".join([self.fs.protocol, prefix])
+                proto_name = protocol_to_string(self.fs.protocol)
+                full_prefix = "_".join([proto_name, prefix])
                 return str(full_prefix / suffix)
 
             return path
@@ -109,7 +117,9 @@ class PinsUrlCache(PinsCache):
 
         # note that we include an extra version folder, so it conforms with
         # pin board path form: <board_path>/<pin_name>/<version_name>/<file>
-        return str(Path(prefix) / PLACEHOLDER_VERSION / final_part)
+        proto_name = protocol_to_string(self.fs.protocol)
+        full_prefix = "_".join([proto_name, prefix])
+        return str(Path(full_prefix) / PLACEHOLDER_VERSION / final_part)
 
 
 class CachePruner:

--- a/pins/cache.py
+++ b/pins/cache.py
@@ -1,0 +1,30 @@
+from fsspec.implementations.cached import WholeFileCacheFileSystem, hash_name
+from fsspec import register_implementation
+from pathlib import Path
+
+
+class PinsCache(WholeFileCacheFileSystem):
+    protocol = "pinscache"
+
+    def _make_local_details(self, path):
+        # modifies method to create any parent directories needed by the cached file
+        # note that this is called in ._open(), at the point it's known the file
+        # will be cached
+        fn = super()._make_local_details(path)
+        Path(fn).parent.mkdir(parents=True, exist_ok=True)
+
+        return fn
+
+    def hash_name(self, path, same_name):
+        # the main change in this function is that, for same_name, it returns
+        # the full path
+        if same_name:
+            hash = path
+        else:
+            hash = hash_name(path, same_name)
+
+        return hash
+
+
+# TODO: swap to use entrypoint
+register_implementation("pinscache", PinsCache)

--- a/pins/cache.py
+++ b/pins/cache.py
@@ -33,6 +33,15 @@ def touch_access_time(path, access_time: "float | None" = None):
 class PinsCache(SimpleCacheFileSystem):
     protocol = "pinscache"
 
+    def _open(self, path, *args, **kwargs):
+        # For some reason, the open method of SimpleCacheFileSystem doesn't
+        # call _make_local_details, so we need to patch in here.
+        # Note that methods like .cat() do call it. Other Caches don't have this issue.
+        path = self._strip_protocol(path)
+        self._make_local_details(path)
+
+        return super()._open(path, *args, **kwargs)
+
     def _make_local_details(self, path):
         # modifies method to create any parent directories needed by the cached file
         # note that this is called in ._open(), at the point it's known the file

--- a/pins/cache.py
+++ b/pins/cache.py
@@ -1,9 +1,36 @@
-from fsspec.implementations.cached import WholeFileCacheFileSystem, hash_name
+import humanize
+import os
+import time
+import shutil
+
+from fsspec.implementations.cached import SimpleCacheFileSystem, hash_name
 from fsspec import register_implementation
 from pathlib import Path
 
+from .config import get_cache_dir
 
-class PinsCache(WholeFileCacheFileSystem):
+
+def touch_access_time(path, access_time: "float | None" = None):
+    """Update access time of file.
+
+    Returns the new access time.
+    """
+
+    if access_time is None:
+        access_time = time.time()
+
+    p = Path(path)
+
+    if not p.exists():
+        p.touch()
+
+    stat = p.stat()
+    os.utime(path, (access_time, stat.st_mtime))
+
+    return access_time
+
+
+class PinsCache(SimpleCacheFileSystem):
     protocol = "pinscache"
 
     def _make_local_details(self, path):
@@ -25,6 +52,115 @@ class PinsCache(WholeFileCacheFileSystem):
 
         return hash
 
+    def touch_access_time(path):
+        return touch_access_time(path)
+
+
+class CachePruner:
+    """Prunes the cache directory, across multiple boards.
+
+    Note
+    ----
+
+    `pins` assumes that all boards cache using these rules:
+
+    * path structure: `<cache_root>/<board_hash>/<pin>/<version>`.
+    * each version has a data.txt file in it.
+    """
+
+    meta_path = "data.txt"
+
+    def __init__(self, cache_dir: "str | Path"):
+        self.cache_dir = Path(cache_dir)
+
+    def versions(self) -> "iter[Path]":
+        for p_version in self.cache_dir.glob("*/*"):
+            if p_version.is_dir() and (p_version / self.meta_path).exists():
+                yield p_version
+
+    def should_prune_version(self, days, path: "str | Path"):
+        path = Path(path)
+
+        expiry_time_sec = days * 60 * 60 * 24
+        prune_before = time.time() - expiry_time_sec
+
+        p_meta = path / self.meta_path
+
+        if not p_meta.exists():
+            raise FileNotFoundError(f"No metadata file: {p_meta.absolute()}")
+
+        access_time = p_meta.stat().st_atime
+        return access_time < prune_before
+
+    def old_versions(self, days):
+        return [p for p in self.versions() if self.should_prune_version(days, p)]
+
+    def prune(self, days=30):
+        to_prune = self.old_versions(days)
+        size = sum(map(disk_usage, to_prune))
+
+        # TODO: clean this up, general approach to prompting
+        confirmed = prompt_cache_prune(to_prune, size)
+        if confirmed:
+            for path in to_prune:
+                delete_version(to_prune)
+
+        print("Skipping cache deletion")
+
+
+def delete_version(path: "str | Path"):
+    path = Path(path)
+    shutil.rmtree(str(path.absolute()))
+
+
+def disk_usage(path):
+    return sum(p.stat().st_size for p in path.glob("**/*") if p.is_file() or p.is_dir())
+
+
+def prompt_cache_prune(to_prune, size) -> bool:
+    print(to_prune)
+    human_size = humanize.naturalsize(size, binary=True)
+    resp = input(f"Delete {len(to_prune)} pin versions, freeing {human_size}?")
+    return resp == "yes"
+
+
+def cache_prune(days=30, cache_root=None, prompt=True):
+    if cache_root is None:
+        cache_root = get_cache_dir()
+
+    final_delete = []
+    for p_board in Path(cache_root).glob("*"):
+        pruner = CachePruner(p_board)
+        final_delete.extend(pruner.old_versions(days))
+
+    size = sum(map(disk_usage, final_delete))
+
+    if prompt:
+        confirmed = prompt_cache_prune(final_delete, size)
+    else:
+        confirmed = True
+    if confirmed:
+        for p in final_delete:
+            delete_version(p)
+
+
+# def prune_files(days = 30, path = None):
+#     if path is None:
+#         for p_cache in Path(get_cache_dir()).glob("*"):
+#             return prune_files(days=days, path=str(p_cache.absolute()))
+#
+#     expiry_time_sec = days * 60 * 60 * 24
+#     fs_cache = PinsCache(
+#         target_protocol=None,
+#         cache_storage=path,
+#         check_files=True,
+#         expiry_time=expiry_time_sec
+#     )
+#
+#     # note that fsspec considers only the last entry in cached_files deletable
+#     for hash_path, entry in fs_cache.cached_files[-1].items():
+#         if time.time() - detail["time"] > self.expiry:
+#             fs_cache.pop_from_cache(entry["original"])
 
 # TODO: swap to use entrypoint
 register_implementation("pinscache", PinsCache)

--- a/pins/config.py
+++ b/pins/config.py
@@ -1,10 +1,12 @@
 import appdirs
 import os
 
+PINS_NAME = "pins-py"
+
 
 def get_data_dir():
-    return os.environ.get("PINS_DATA_DIR", appdirs.user_data_dir("pins"))
+    return os.environ.get("PINS_DATA_DIR", appdirs.user_data_dir(PINS_NAME))
 
 
 def get_cache_dir():
-    return os.environ.get("PINS_CACHE_DIR", appdirs.user_cache_dir("pins"))
+    return os.environ.get("PINS_CACHE_DIR", appdirs.user_cache_dir(PINS_NAME))

--- a/pins/config.py
+++ b/pins/config.py
@@ -1,0 +1,10 @@
+import appdirs
+import os
+
+
+def get_data_dir():
+    return os.environ.get("PINS_DATA_DIR", appdirs.user_data_dir("pins"))
+
+
+def get_cache_dir():
+    return os.environ.get("PINS_CACHE_DIR", appdirs.user_cache_dir("pins"))

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -1,4 +1,3 @@
-import appdirs
 import fsspec
 import os
 import tempfile
@@ -7,6 +6,7 @@ from pathlib import Path
 
 from .boards import BaseBoard, BoardRsConnect, BoardManual
 from .cache import PinsCache
+from .config import get_data_dir, get_cache_dir
 
 
 class DEFAULT:
@@ -16,14 +16,6 @@ class DEFAULT:
 # Board constructors ==========================================================
 # note that libraries not used by board classes above are imported within these
 # functions. may be worth moving these funcs into their own module.
-
-
-def get_data_dir():
-    return os.environ.get("PINS_DATA_DIR", appdirs.user_data_dir("pins"))
-
-
-def get_cache_dir():
-    return os.environ.get("PINS_CACHE_DIR", appdirs.user_cache_dir("pins"))
 
 
 def board(

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 
 from .boards import BaseBoard, BoardRsConnect, BoardManual
-from .cache import PinsCache
+from .cache import PinsCache, PinsUrlCache
 from .config import get_data_dir, get_cache_dir
 
 
@@ -164,12 +164,18 @@ def board_urls(path: str, pin_paths: dict, cache=DEFAULT):
     ['df_csv', 'df_arrow']
     """
 
-    # TODO(question): R pins' version is named board_url (no s)
+    # TODO(compat): R pins' version is named board_url (no s)
+    if cache is DEFAULT:
+        # copied from board(). this ensures that paths in cache have the form:
+        # <full_path_hash>/<version_placeholder>/<file_name>
+        cache_dir = get_cache_dir()
+        fs = PinsUrlCache(
+            target_protocol="http", cache_storage=cache_dir, same_names=True
+        )
+    else:
+        raise NotImplementedError("Can't currently pass own cache object")
 
-    def build_board(*args, **kwargs):
-        return BoardManual(*args, **kwargs, pin_paths=pin_paths)
-
-    return board("http", path, True, cache, board_factory=build_board)
+    return BoardManual(path, fs, versioned=True, pin_paths=pin_paths)
 
 
 def board_rsconnect(versioned=True, server_url=None, api_key=None, cache=DEFAULT):

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -2,8 +2,6 @@ import fsspec
 import os
 import tempfile
 
-from pathlib import Path
-
 from .boards import BaseBoard, BoardRsConnect, BoardManual
 from .cache import PinsCache
 from .config import get_data_dir, get_cache_dir
@@ -63,9 +61,10 @@ def board(
     # wrap fs in cache ----
 
     if cache is DEFAULT:
-        cache_base = get_cache_dir()
-        cache_dir = str(Path(cache_base) / protocol)
-        fs = PinsCache(cache_storage=cache_dir, fs=fs, same_names=True)
+        cache_dir = get_cache_dir()
+        fs = PinsCache(
+            cache_storage=cache_dir, fs=fs, hash_prefix=path, same_names=True
+        )
     elif cache is None:
         pass
     else:

--- a/pins/drivers.py
+++ b/pins/drivers.py
@@ -1,5 +1,7 @@
 import builtins
 
+from pathlib import Path
+
 from .meta import Meta
 
 
@@ -7,7 +9,7 @@ from .meta import Meta
 # from .boards import IFileSystem
 
 
-def load_data(meta: Meta, fs, path_to_version: str):
+def load_data(meta: Meta, fs, path_to_version: "str | None" = None):
     """Return loaded data, based on meta type.
     Parameters
     ----------
@@ -25,8 +27,12 @@ def load_data(meta: Meta, fs, path_to_version: str):
     if len(fnames) > 1:
         raise ValueError("Cannot load data when more than 1 file")
 
+    # TODO: currently only can load a single file
     target_fname = fnames[0]
-    path_to_file = f"{path_to_version}/{target_fname}"
+    if path_to_version is not None:
+        path_to_file = f"{path_to_version}/{target_fname}"
+    else:
+        path_to_file = target_fname
 
     if meta.type == "csv":
         import pandas as pd
@@ -37,6 +43,10 @@ def load_data(meta: Meta, fs, path_to_version: str):
         import joblib
 
         return joblib.load(fs.open(path_to_file))
+
+    elif meta.type == "file":
+        # TODO: update to handle multiple files
+        return [str(Path(fs.open(path_to_file).name).absolute())]
 
     raise NotImplementedError(f"No driver for type {meta.type}")
 

--- a/pins/meta.py
+++ b/pins/meta.py
@@ -12,6 +12,23 @@ DEFAULT_API_VERSION = 1
 
 
 @dataclass
+class MetaRaw:
+    """Absolute minimum metadata for a pin.
+
+    Parameters
+    ----------
+    file:
+        All relevant files contained in the pin. Note that these be absolute paths
+        to fetch from the target filesystem.
+    type:
+        The type of pin data stored. This is used to determine how to read / write it.
+    """
+
+    file: Union[str, Sequence[str]]
+    type: str
+
+
+@dataclass
 class Meta:
     """Represent metadata for a pin version.
 
@@ -26,7 +43,7 @@ class Meta:
     pin_hash:
         A hash of the pin.
     file:
-        All relevant files contained in the pin.
+        All relevant files in the pin. Should be relative to this pin's folder.
     file_size:
         The total size of the files in the pin.
     type:
@@ -150,6 +167,9 @@ class MetaFactory:
             user=user if user is not None else {},
             version=version,
         )
+
+    def create_raw(self, files: Sequence[StrOrFile], type: str = "file",) -> MetaRaw:
+        return MetaRaw(files, type)
 
     def read_pin_yaml(
         self, f: IOBase, pin_name: str, version: "str | VersionRaw"

--- a/pins/tests/conftest.py
+++ b/pins/tests/conftest.py
@@ -7,7 +7,10 @@ from pytest import mark as m
 from pathlib import Path
 from pins.tests.helpers import BoardBuilder, RscBoardBuilder, Snapshot, rm_env
 
+EXAMPLE_REL_PATH = "pins/tests/pins-compat"
 PATH_TO_EXAMPLE_BOARD = files("pins") / "tests/pins-compat"
+PATH_TO_EXAMPLE_VERSION = PATH_TO_EXAMPLE_BOARD / "df_csv/20220214T163720Z-9bfad/"
+EXAMPLE_PIN_NAME = "df_csv"
 
 
 # Based on https://github.com/machow/siuba/blob/main/siuba/tests/helpers.py
@@ -66,19 +69,19 @@ def tmp_dir2():
 
 
 @pytest.fixture
-def tmp_cache(tmp_dir2):
+def tmp_cache():
     with rm_env("PINS_CACHE_DIR"):
-        os.environ["PINS_CACHE_DIR"] = str(tmp_dir2)
-
-        yield tmp_dir2
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.environ["PINS_CACHE_DIR"] = str(tmp_dir)
+            yield Path(tmp_dir)
 
 
 @pytest.fixture
-def tmp_data_dir(tmp_dir2):
+def tmp_data_dir():
     with rm_env("PINS_DATA_DIR"):
-        os.environ["PINS_DATA_DIR"] = str(tmp_dir2)
-
-        yield tmp_dir2
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.environ["PINS_DATA_DIR"] = str(tmp_dir)
+            yield Path(tmp_dir)
 
 
 def pytest_addoption(parser):

--- a/pins/tests/conftest.py
+++ b/pins/tests/conftest.py
@@ -1,21 +1,28 @@
 import pytest
 import tempfile
+import os
 
 from importlib_resources import files
 from pytest import mark as m
 from pathlib import Path
-from pins.tests.helpers import BoardBuilder, RscBoardBuilder, Snapshot
+from pins.tests.helpers import BoardBuilder, RscBoardBuilder, Snapshot, rm_env
+
+PATH_TO_EXAMPLE_BOARD = files("pins") / "tests/pins-compat"
+
 
 # Based on https://github.com/machow/siuba/blob/main/siuba/tests/helpers.py
 BACKEND_MARKS = ["fs_s3", "fs_file", "fs_rsc"]
 
-param_rsc = pytest.param(lambda: RscBoardBuilder("rsc"), id="rsc", marks=m.fs_rsc)
-
-params_backend = [
+# parameters that can be used more than once per session
+params_safe = [
     pytest.param(lambda: BoardBuilder("file"), id="file", marks=m.fs_file),
     pytest.param(lambda: BoardBuilder("s3"), id="s3", marks=m.fs_s3),
-    param_rsc,
 ]
+
+# rsc should only be used once, because users are created at docker setup time
+param_rsc = pytest.param(lambda: RscBoardBuilder("rsc"), id="rsc", marks=m.fs_rsc)
+
+params_backend = [*params_safe, param_rsc]
 
 
 @pytest.fixture(params=params_backend, scope="session")
@@ -23,6 +30,15 @@ def backend(request):
     backend = request.param()
     yield backend
     backend.teardown()
+
+
+@pytest.fixture(scope="session")
+def http_example_board_path():
+    # backend = BoardBuilder("s3")
+    # yield backend.create_tmp_board(str(PATH_TO_EXAMPLE_BOARD.absolute())).board
+    # backend.teardown()
+    # TODO: could putting it in a publically available bucket folder
+    return "https://raw.githubusercontent.com/machow/pins-python/main/pins/tests/pins-compat"
 
 
 @pytest.fixture
@@ -47,6 +63,22 @@ def tmp_dir2():
     # which recommends using pathlib, etc..
     with tempfile.TemporaryDirectory() as tmp_dir:
         yield Path(tmp_dir)
+
+
+@pytest.fixture
+def tmp_cache(tmp_dir2):
+    with rm_env("PINS_CACHE_DIR"):
+        os.environ["PINS_CACHE_DIR"] = str(tmp_dir2)
+
+        yield tmp_dir2
+
+
+@pytest.fixture
+def tmp_data_dir(tmp_dir2):
+    with rm_env("PINS_DATA_DIR"):
+        os.environ["PINS_DATA_DIR"] = str(tmp_dir2)
+
+        yield tmp_dir2
 
 
 def pytest_addoption(parser):

--- a/pins/tests/helpers.py
+++ b/pins/tests/helpers.py
@@ -1,5 +1,6 @@
 import pytest
 
+import contextlib
 import uuid
 import os
 import json
@@ -104,7 +105,8 @@ class BoardBuilder:
         self.fs_name = fs_name
         self.board_path_registry = []
 
-    def get_param_from_env(self, entry):
+    @staticmethod
+    def get_param_from_env(entry):
         name, default = entry
 
         value = os.environ.get(name, default)
@@ -249,3 +251,22 @@ class Snapshot:
             shutil.copy(dst_file, self.path)
 
         assert self.path.read_text() == Path(dst_file).read_text()
+
+
+@contextlib.contextmanager
+def rm_env(*args):
+    """
+    Temporarily set the process environment variables.
+
+
+    """
+    old_environ = dict(os.environ)
+    for arg in args:
+        if arg in os.environ:
+            del os.environ[arg]
+
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)

--- a/pins/tests/test_cache.py
+++ b/pins/tests/test_cache.py
@@ -1,0 +1,116 @@
+import time
+import shutil
+
+import pytest
+from pins.cache import CachePruner, touch_access_time, cache_prune
+
+
+@pytest.fixture
+def some_file(tmp_dir2):
+    p = tmp_dir2 / "some_file.txt"
+    p.touch()
+    return p
+
+
+def test_touch_access_time_manual(some_file):
+    some_file.stat().st_atime
+
+    access_time = time.time() - 60 * 60 * 24
+    touch_access_time(some_file, access_time)
+
+    assert some_file.stat().st_atime == access_time
+
+
+def test_touch_access_time_auto(some_file):
+    orig_access = some_file.stat().st_atime
+
+    time.sleep(0.2)
+    new_time = touch_access_time(some_file)
+
+    assert some_file.stat().st_atime == new_time
+    assert orig_access < new_time
+
+
+# Cache pruning ===============================================================
+
+
+@pytest.fixture
+def a_cache(tmp_dir2):
+    return tmp_dir2
+
+
+def create_metadata(p, access_time):
+    p.mkdir(parents=True, exist_ok=True)
+    meta = p / "data.txt"
+    meta.touch()
+    touch_access_time(meta, access_time)
+
+
+@pytest.fixture
+def pin1_v1(a_cache):  # current
+    v1 = a_cache / "a_pin" / "version_1"
+    create_metadata(v1, time.time())
+
+    return v1
+
+
+@pytest.fixture
+def pin1_v2(a_cache):
+    v2 = a_cache / "a_pin" / "version_2"
+    create_metadata(v2, time.time() - 60 * 60 * 24)  # one day ago
+
+    return v2
+
+
+@pytest.fixture
+def pin2_v3(a_cache):
+    v3 = a_cache / "other_pin" / "version_3"
+    create_metadata(v3, time.time() - 60 * 60 * 48)  # two days ago
+
+    return v3
+
+
+def test_cache_pruner_old_versions_none(a_cache, pin1_v1):
+    pruner = CachePruner(a_cache)
+
+    old = pruner.old_versions(days=1)
+
+    assert len(old) == 0
+
+
+def test_cache_pruner_old_versions_days0(a_cache, pin1_v1):
+    pruner = CachePruner(a_cache)
+    old = pruner.old_versions(days=0)
+
+    assert len(old) == 1
+    assert old[0] == pin1_v1
+
+
+def test_cache_pruner_old_versions_some(a_cache, pin1_v1, pin1_v2):
+    # create: tmp_dir/pin1/version1
+
+    pruner = CachePruner(a_cache)
+
+    old = pruner.old_versions(days=1)
+
+    assert len(old) == 1
+    assert old[0] == pin1_v2
+
+
+def test_cache_pruner_old_versions_multi_pins(a_cache, pin1_v2, pin2_v3):
+    pruner = CachePruner(a_cache)
+    old = pruner.old_versions(days=1)
+
+    assert len(old) == 2
+    assert set(old) == {pin1_v2, pin2_v3}
+
+
+def test_cache_prune_prompt(tmp_dir2, a_cache, pin1_v1, pin2_v3, monkeypatch):
+    p_board = tmp_dir2 / "a_board"
+    shutil.copytree(a_cache, p_board)
+    cache_prune(days=1, cache_root=tmp_dir2, prompt=False)
+
+    versions = list(p_board.glob("*/*"))
+
+    # pin2_v3 deleted
+    assert len(versions) == 1

--- a/pins/tests/test_cache.py
+++ b/pins/tests/test_cache.py
@@ -2,7 +2,18 @@ import time
 import shutil
 
 import pytest
-from pins.cache import CachePruner, touch_access_time, cache_prune
+from pins.cache import (
+    CachePruner,
+    touch_access_time,
+    cache_prune,
+    PinsCache,
+    PinsUrlCache,
+)
+
+from fsspec import filesystem
+
+
+# Utilities ===================================================================
 
 
 @pytest.fixture
@@ -29,6 +40,31 @@ def test_touch_access_time_auto(some_file):
 
     assert some_file.stat().st_atime == new_time
     assert orig_access < new_time
+
+
+# Cache Classes ===============================================================
+
+# Boards w/ default cache =====================================================
+
+
+def test_pins_cache_hash_name_preserves():
+    cache = PinsCache(fs=filesystem("file"))
+    assert cache.hash_name("a/b/c.txt", True) == "a/b/c.txt"
+
+
+def test_pins_cache_url_hash_name():
+    cache = PinsUrlCache(fs=filesystem("file"))
+    hashed = cache.hash_name("http://example.com/a.txt", True)
+
+    # should have form <url_hash>/<version_placeholder>/<filename>
+    assert hashed.endswith("/a.txt")
+    assert hashed.count("/") == 2
+
+
+@pytest.mark.skip("TODO")
+def test_pins_cache_open():
+    # check that opening works and creates the cached file
+    pass
 
 
 # Cache pruning ===============================================================

--- a/pins/tests/test_compat.py
+++ b/pins/tests/test_compat.py
@@ -1,24 +1,21 @@
 import pytest
 import datetime
 
-import importlib_resources as resources
 
 from pins.errors import PinsError
 from pins.tests.helpers import xfail_fs
+from pins.tests.conftest import PATH_TO_EXAMPLE_BOARD
 
 
 NOT_A_PIN = "not_a_pin_abcdefg"
 PIN_CSV = "df_csv"
-
-path_to_board = resources.files("pins") / "tests/pins-compat"
-
 
 # set up board ----
 
 
 @pytest.fixture(scope="session")
 def board(backend):
-    board = backend.create_tmp_board(str(path_to_board.absolute()))
+    board = backend.create_tmp_board(str(PATH_TO_EXAMPLE_BOARD.absolute()))
 
     yield board
 
@@ -112,7 +109,7 @@ def test_compat_pin_meta_version_arg_error(board):
 def test_compat_pin_read(board):
     import pandas as pd
 
-    p_data = path_to_board / "df_csv" / "20220214T163720Z-9bfad" / "df_csv.csv"
+    p_data = PATH_TO_EXAMPLE_BOARD / "df_csv" / "20220214T163720Z-9bfad" / "df_csv.csv"
 
     src_df = board.pin_read("df_csv")
     dst_df = pd.read_csv(p_data, index_col=0)

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -102,7 +102,7 @@ def test_constructor_board(board, df_csv, tmp_cache):
     fs_name = prot if isinstance(prot, str) else prot[0]
 
     if fs_name == "file":
-        con_name = "local"
+        con_name = "folder"
     elif fs_name == "rsc":
         con_name = "rsconnect"
         pytest.xfail()
@@ -116,14 +116,18 @@ def test_constructor_board(board, df_csv, tmp_cache):
     assert_frame_equal(df, df_csv)
 
     # check cache
-    options = list(tmp_cache.glob("s3_*"))
-    assert len(options) == 1
+    if fs_name == "file":
+        # no caching for local file boards
+        pass
+    else:
+        options = list(tmp_cache.glob("*"))
+        assert len(options) == 1
 
-    cache_dir = options[0]
-    res = list(cache_dir.rglob("**/*.csv"))
-    assert len(res) == 1
+        cache_dir = options[0]
+        res = list(cache_dir.rglob("**/*.csv"))
+        assert len(res) == 1
 
-    check_cache_file_path(res[0], cache_dir)
+        check_cache_file_path(res[0], cache_dir)
 
 
 # Board particulars ===========================================================

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -33,6 +33,9 @@ def check_dir_writable(p_dir):
     assert os.access(p_dir.parent.absolute(), os.W_OK)
 
 
+# Board particulars ===========================================================
+
+
 @pytest.mark.skip_on_github
 def test_board_constructor_local_default_writable():
 

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -29,8 +29,8 @@ def rm_env(*args):
 
 
 def check_dir_writable(p_dir):
-    assert p_dir.exists()
-    assert os.access(p_dir.absolute(), os.W_OK)
+    assert p_dir.parent.exists()
+    assert os.access(p_dir.parent.absolute(), os.W_OK)
 
 
 @pytest.mark.skip_on_github
@@ -41,7 +41,7 @@ def test_board_constructor_local_default_writable():
         p_board = Path(board.board)
 
         check_dir_writable(p_board)
-        assert p_board.name == "pins"
+        assert p_board.name == "pins-py"
 
 
 def test_board_constructor_temp_writable():

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -50,9 +50,9 @@ charset-normalizer==2.0.12
     # via
     #   aiohttp
     #   requests
-click==8.0.4
+click==8.1.0
     # via pip-tools
-debugpy==1.5.1
+debugpy==1.6.0
     # via ipykernel
 decopatch==1.4.10
     # via pytest-cases
@@ -79,6 +79,8 @@ fsspec==2022.02.0
     # via
     #   pins (setup.cfg)
     #   s3fs
+humanize==4.0.0
+    # via pins (setup.cfg)
 idna==3.3
     # via
     #   requests
@@ -87,19 +89,19 @@ imagesize==1.3.0
     # via sphinx
 importlib-metadata==4.11.3
     # via sphinx
-importlib-resources==5.4.0
+importlib-resources==5.6.0
     # via
     #   jsonschema
     #   pins (setup.cfg)
 iniconfig==1.1.1
     # via pytest
-ipykernel==6.9.2
+ipykernel==6.10.0
     # via pins (setup.cfg)
-ipython==8.1.1
+ipython==8.2.0
     # via ipykernel
 jedi==0.18.1
     # via ipython
-jinja2==3.0.3
+jinja2==3.1.1
     # via
     #   nbconvert
     #   nbsphinx
@@ -111,7 +113,7 @@ joblib==1.1.0
     # via pins (setup.cfg)
 jsonschema==4.4.0
     # via nbformat
-jupyter-client==7.1.2
+jupyter-client==7.2.0
     # via
     #   ipykernel
     #   nbclient
@@ -133,7 +135,9 @@ markdown-it-py==1.1.0
     #   jupytext
     #   mdit-py-plugins
 markupsafe==2.1.1
-    # via jinja2
+    # via
+    #   jinja2
+    #   nbconvert
 matplotlib-inline==0.1.3
     # via
     #   ipykernel
@@ -148,7 +152,7 @@ multidict==6.0.2
     #   yarl
 nbclient==0.5.13
     # via nbconvert
-nbconvert==6.4.4
+nbconvert==6.4.5
     # via nbsphinx
 nbformat==5.2.0
     # via
@@ -170,6 +174,7 @@ numpy==1.22.3
 packaging==21.3
     # via
     #   bleach
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
 pandas==1.4.1
@@ -200,7 +205,7 @@ pure-eval==0.2.2
     # via stack-data
 py==1.11.0
     # via pytest
-pydata-sphinx-theme==0.8.0
+pydata-sphinx-theme==0.8.1
     # via pins (setup.cfg)
 pygments==2.11.2
     # via
@@ -225,7 +230,7 @@ python-dateutil==2.8.2
     #   botocore
     #   jupyter-client
     #   pandas
-python-dotenv==0.19.2
+python-dotenv==0.20.0
     # via pytest-dotenv
 pytz==2022.1
     # via
@@ -242,7 +247,7 @@ requests==2.27.1
     # via sphinx
 s3fs==2022.2.0
     # via pins (setup.cfg)
-siuba==0.1.2
+siuba==0.2.0
     # via pins (setup.cfg)
 six==1.16.0
     # via
@@ -252,7 +257,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.3.1
     # via beautifulsoup4
-sphinx==4.4.0
+sphinx==4.5.0
     # via
     #   nbsphinx
     #   pins (setup.cfg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     importlib-resources
     appdirs
     siuba
+    humanize
 
 
 [options.extras_require]


### PR DESCRIPTION
Implements a cache that preserves the structure of a pin board. E.g. a file named `<some_pin>/<some_version>/mtcars.csv`, will be nested in its pin and version directory in the cache. This is unusual for the cache, which normally hashes the path and lets fsspec handle where the file is accessed from.

TODO:

* implement `cache_prune`, `cache_info` (#37)
* test all current constructors
* Punt on cache_browse, implement together with pin_browse (#52)

UNANTICIPATED TODO:

* modify BoardManual to handle downloading of single files (#54 ) / add a special cache for it in the process