### PR TITLE
feat!: require user to opt-in to read unsafe pins

### DIFF
--- a/docs/getting_started.Rmd
+++ b/docs/getting_started.Rmd
@@ -130,6 +130,9 @@ While we’ll do our best to keep the automatically generated metadata consisten
 ## 🚧 Versioning
 
 
+> ⚠️: Warning the examples in this section use joblib to read and write data. Joblib uses the pickle format, and **pickle files are not secure**. Only read pickle files you trust. In order to read pickle files, set the `allow_pickle_read=True` argument. See: https://docs.python.org/3/library/pickle.html.
+
+
 > ⚠️: versioning is not yet implemented. These docs are copied from R pins.
 
 In many situations it's useful to version pins, so that writing to an existing pin does not replace the existing data, but instead adds a new copy.
@@ -154,9 +157,8 @@ The primary exception is `board_folder()` since that stores data on your compute
 Once you have turned versioning on, every `pin_write()` will create a new version:
 
 ```{python}
-# TODO: can save lists using joblib, but should warn about security
+board2 = board_temp(versioned = True, allow_pickle_read=True)
 
-board2 = board_temp(versioned = True)
 board2.pin_write([1,2,3,4,5], name = "x", type = "joblib", title="TODO")
 board2.pin_write([1,2,3], name = "x", type = "joblib", title="TODO")
 board2.pin_write([1,2], name = "x", type = "joblib", title="TODO")

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -50,7 +50,7 @@ class BaseBoard:
         fs: IFileSystem,
         versioned=True,
         meta_factory=MetaFactory(),
-        allow_insecure_read: "bool | None" = None,
+        allow_pickle_read: "bool | None" = None,
     ):
         self.board = str(board)
         self.fs = fs
@@ -60,7 +60,7 @@ class BaseBoard:
             raise NotImplementedError()
 
         self.versioned = versioned
-        self.allow_insecure_read = allow_insecure_read
+        self.allow_pickle_read = allow_pickle_read
 
     def pin_exists(self, name: str) -> bool:
         """Determine if a pin exists.
@@ -206,7 +206,7 @@ class BaseBoard:
             meta,
             self.fs,
             self.construct_path([pin_name, meta.version.version]),
-            allow_insecure_read=self.allow_insecure_read,
+            allow_pickle_read=self.allow_pickle_read,
         )
 
     def pin_write(
@@ -609,7 +609,7 @@ class BoardManual(BaseBoard):
 
         if isinstance(meta, MetaRaw):
             return load_data(
-                meta, self.fs, None, allow_insecure_read=self.allow_insecure_read
+                meta, self.fs, None, allow_pickle_read=self.allow_pickle_read
             )
 
         raise NotImplementedError("TODO: allow download beyond MetaRaw.")

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -50,6 +50,7 @@ class BaseBoard:
         fs: IFileSystem,
         versioned=True,
         meta_factory=MetaFactory(),
+        allow_insecure_read: "bool | None" = None,
     ):
         self.board = str(board)
         self.fs = fs
@@ -59,6 +60,7 @@ class BaseBoard:
             raise NotImplementedError()
 
         self.versioned = versioned
+        self.allow_insecure_read = allow_insecure_read
 
     def pin_exists(self, name: str) -> bool:
         """Determine if a pin exists.
@@ -201,7 +203,10 @@ class BaseBoard:
         pin_name = self.path_to_pin(name)
 
         return load_data(
-            meta, self.fs, self.construct_path([pin_name, meta.version.version])
+            meta,
+            self.fs,
+            self.construct_path([pin_name, meta.version.version]),
+            allow_insecure_read=self.allow_insecure_read,
         )
 
     def pin_write(
@@ -603,7 +608,9 @@ class BoardManual(BaseBoard):
         meta = self.pin_meta(name, version)
 
         if isinstance(meta, MetaRaw):
-            return load_data(meta, self.fs, None)
+            return load_data(
+                meta, self.fs, None, allow_insecure_read=self.allow_insecure_read
+            )
 
         raise NotImplementedError("TODO: allow download beyond MetaRaw.")
 

--- a/pins/config.py
+++ b/pins/config.py
@@ -2,11 +2,30 @@ import appdirs
 import os
 
 PINS_NAME = "pins-py"
+PINS_ENV_DATA_DIR = "PINS_DATA_DIR"
+PINS_ENV_CACHE_DIR = "PINS_CACHE_DIR"
+PINS_ENV_INSECURE_READ = "PINS_ALLOW_INSECURE_READ"
 
 
 def get_data_dir():
-    return os.environ.get("PINS_DATA_DIR", appdirs.user_data_dir(PINS_NAME))
+    return os.environ.get(PINS_ENV_DATA_DIR, appdirs.user_data_dir(PINS_NAME))
 
 
 def get_cache_dir():
-    return os.environ.get("PINS_CACHE_DIR", appdirs.user_cache_dir(PINS_NAME))
+    return os.environ.get(PINS_ENV_CACHE_DIR, appdirs.user_cache_dir(PINS_NAME))
+
+
+def get_allow_insecure_read(flag):
+    if flag is None:
+        env_var = os.environ.get(PINS_ENV_INSECURE_READ, "0")
+        try:
+            env_int = int(env_var)
+        except ValueError:
+            raise ValueError(
+                f"{PINS_ENV_INSECURE_READ} must be '0' or '1', but was set to "
+                f"{repr(env_var)}."
+            )
+
+        flag = bool(env_int)
+
+    return flag

--- a/pins/config.py
+++ b/pins/config.py
@@ -4,7 +4,7 @@ import os
 PINS_NAME = "pins-py"
 PINS_ENV_DATA_DIR = "PINS_DATA_DIR"
 PINS_ENV_CACHE_DIR = "PINS_CACHE_DIR"
-PINS_ENV_INSECURE_READ = "PINS_ALLOW_INSECURE_READ"
+PINS_ENV_INSECURE_READ = "PINS_ALLOW_PICKLE_READ"
 
 
 def get_data_dir():
@@ -15,7 +15,7 @@ def get_cache_dir():
     return os.environ.get(PINS_ENV_CACHE_DIR, appdirs.user_cache_dir(PINS_NAME))
 
 
-def get_allow_insecure_read(flag):
+def get_allow_pickle_read(flag):
     if flag is None:
         env_var = os.environ.get(PINS_ENV_INSECURE_READ, "0")
         try:

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -95,13 +95,31 @@ def board(
 # TODO(#31): change file boards to unversioned once implemented
 
 
-def board_folder(path, versioned=True, allow_pickle_read=None):
+def board_folder(path: str, versioned=True, allow_pickle_read=None):
+    """Create a pins board inside a folder.
+
+    Parameters
+    ----------
+    path:
+        The folder that will hold the board.
+    **kwargs:
+        Passed to the pins.board function.
+    """
+
     return board(
         "file", path, versioned, cache=None, allow_pickle_read=allow_pickle_read
     )
 
 
 def board_temp(versioned=True, allow_pickle_read=None):
+    """Create a pins board in a temporary directory.
+
+    Parameters
+    ----------
+    **kwargs:
+        Passed to the pins.board function.
+    """
+
     tmp_dir = tempfile.TemporaryDirectory()
 
     board_obj = board(
@@ -117,6 +135,13 @@ def board_temp(versioned=True, allow_pickle_read=None):
 
 
 def board_local(versioned=True, allow_pickle_read=None):
+    """Create a board in a system data directory.
+
+    Parameters
+    ----------
+    **kwargs:
+        Passed to the pins.board function.
+    """
     path = get_data_dir()
 
     return board(
@@ -131,15 +156,14 @@ def board_github(
 
     Parameters
     ----------
-    path:
-        TODO
-    versioned:
-        TODO
     org:
         Name of the github org (e.g. user account).
     repo:
         Name of the repo.
-
+    path:
+        A subfolder in the github repo holding the board.
+    **kwargs:
+        Passed to the pins.board function.
 
     Note
     ----
@@ -172,7 +196,16 @@ def board_github(
 
 
 def board_urls(path: str, pin_paths: dict, cache=DEFAULT, allow_pickle_read=None):
-    """
+    """Create a board from individual urls.
+
+    Parameters
+    ----------
+    path:
+        A base url to prefix all individual pin urls with.
+    pin_paths: Mapping
+        A dictionary mapping pin name to pin url .
+    **kwargs:
+        Passed to the pins.board function.
 
     Example
     -------
@@ -210,14 +243,17 @@ def board_urls(path: str, pin_paths: dict, cache=DEFAULT, allow_pickle_read=None
 def board_rsconnect(
     versioned=True, server_url=None, api_key=None, cache=DEFAULT, allow_pickle_read=None
 ):
-    """
+    """Create a board to read and write pins from an RStudio Connect instance.
 
     Parameters
     ----------
     server_url:
-        TODO
+        Url to the RStudio Connect server.
     api_key:
-        TODO
+        API key for server. If not specified, pins will attempt to read it from
+        CONNECT_API_KEY environment variable.
+    **kwargs:
+        Passed to the pins.board function.
     """
 
     # TODO: api_key can be passed in to underlying RscApi, equiv to R's manual mode
@@ -231,5 +267,14 @@ def board_rsconnect(
 
 
 def board_s3(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
+    """Create a board to read and write pins from an AWS S3 bucket folder.
+
+    Parameters
+    ----------
+    path:
+        Path of form <bucket_name>/<optional>/<subdirectory>.
+    **kwargs:
+        Passed to the pins.board function.
+    """
     # TODO: user should be able to specify storage options here?
     return board("s3", path, versioned, cache, allow_pickle_read)

--- a/pins/drivers.py
+++ b/pins/drivers.py
@@ -2,7 +2,7 @@ import builtins
 
 from pathlib import Path
 
-from .config import get_allow_insecure_read, PINS_ENV_INSECURE_READ
+from .config import get_allow_pickle_read, PINS_ENV_INSECURE_READ
 from .meta import Meta
 from .errors import PinsInsecureReadError
 
@@ -17,7 +17,7 @@ def load_data(
     meta: Meta,
     fs,
     path_to_version: "str | None" = None,
-    allow_insecure_read: "bool | None" = None,
+    allow_pickle_read: "bool | None" = None,
 ):
     """Return loaded data, based on meta type.
     Parameters
@@ -30,10 +30,11 @@ def load_data(
         A filepath used as the parent directory the data to-be-loaded lives in.
     """
     # TODO: extandable loading with deferred importing
-    if meta.type in UNSAFE_TYPES and not get_allow_insecure_read(allow_insecure_read):
+    if meta.type in UNSAFE_TYPES and not get_allow_pickle_read(allow_pickle_read):
         raise PinsInsecureReadError(
-            f"Reading pin type {meta.type} is NOT secure. Set the allow_insecure_read=True "
-            f"when creating the board, or the {PINS_ENV_INSECURE_READ}=1 environment variable.\n"
+            f"Reading pin type {meta.type} involves reading a pickle file, so is NOT secure."
+            f"Set the allow_pickle_read=True when creating the board, or the "
+            f"{PINS_ENV_INSECURE_READ}=1 environment variable.\n"
             "See:\n"
             "  * https://docs.python.org/3/library/pickle.html \n"
             "  * https://scikit-learn.org/stable/modules/model_persistence.html#security-maintainability-limitations"

--- a/pins/errors.py
+++ b/pins/errors.py
@@ -4,3 +4,7 @@ class PinsError(Exception):
 
 class PinsVersionError(PinsError):
     pass
+
+
+class PinsInsecureReadError(PinsError):
+    pass

--- a/pins/tests/test_boards.py
+++ b/pins/tests/test_boards.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from pins.tests.helpers import DEFAULT_CREATION_DATE, rm_env
+from pins.config import PINS_ENV_INSECURE_READ
 from pins.errors import PinsError, PinsInsecureReadError
 from pins.meta import MetaRaw
 
@@ -112,8 +113,8 @@ def test_board_pin_write_rsc_index_html(board, tmp_dir2, snapshot):
     "obj, type_", [(df, "csv"), (df, "joblib"), ({"a": 1, "b": [2, 3]}, "joblib")]
 )
 def test_board_pin_write_type(board, obj, type_, request):
-    with rm_env("PINS_ALLOW_INSECURE_READ"):
-        os.environ["PINS_ALLOW_INSECURE_READ"] = "1"
+    with rm_env(PINS_ENV_INSECURE_READ):
+        os.environ[PINS_ENV_INSECURE_READ] = "1"
         meta = board.pin_write(obj, "test_pin", type=type_, title="some title")
         dst_obj = board.pin_read("test_pin")
 
@@ -135,9 +136,9 @@ def test_board_pin_read_insecure_fail_default(board):
 
 def test_board_pin_read_insecure_fail_board_flag(board):
     # board flag prioritized over env var
-    with rm_env("PINS_ALLOW_INSECURE_READ"):
-        os.environ["PINS_ALLOW_INSECURE_READ"] = "1"
-        board.allow_insecure_read = False
+    with rm_env(PINS_ENV_INSECURE_READ):
+        os.environ[PINS_ENV_INSECURE_READ] = "1"
+        board.allow_pickle_read = False
         board.pin_write({"a": 1}, "test_pin", type="joblib", title="some title")
         with pytest.raises(PinsInsecureReadError):
             board.pin_read("test_pin")
@@ -145,9 +146,9 @@ def test_board_pin_read_insecure_fail_board_flag(board):
 
 def test_board_pin_read_insecure_succeed_board_flag(board):
     # board flag prioritized over env var
-    with rm_env("PINS_ALLOW_INSECURE_READ"):
-        os.environ["PINS_ALLOW_INSECURE_READ"] = "0"
-        board.allow_insecure_read = True
+    with rm_env(PINS_ENV_INSECURE_READ):
+        os.environ[PINS_ENV_INSECURE_READ] = "0"
+        board.allow_pickle_read = True
         board.pin_write({"a": 1}, "test_pin", type="joblib", title="some title")
         board.pin_read("test_pin")
 

--- a/pins/tests/test_config.py
+++ b/pins/tests/test_config.py
@@ -15,22 +15,22 @@ def env_unset():
         yield
 
 
-def test_allow_insecure_read_no_env(env_unset):
-    assert config.get_allow_insecure_read(True) is True
-    assert config.get_allow_insecure_read(False) is False
+def test_allow_pickle_read_no_env(env_unset):
+    assert config.get_allow_pickle_read(True) is True
+    assert config.get_allow_pickle_read(False) is False
 
 
-def test_allow_insecure_read_env_1(env_unset):
+def test_allow_pickle_read_env_1(env_unset):
     os.environ[config.PINS_ENV_INSECURE_READ] = "1"
 
-    assert config.get_allow_insecure_read(True) is True
-    assert config.get_allow_insecure_read(False) is False
-    assert config.get_allow_insecure_read(None) is True
+    assert config.get_allow_pickle_read(True) is True
+    assert config.get_allow_pickle_read(False) is False
+    assert config.get_allow_pickle_read(None) is True
 
 
-def test_allow_insecure_read_env_0(env_unset):
+def test_allow_pickle_read_env_0(env_unset):
     os.environ[config.PINS_ENV_INSECURE_READ] = "0"
 
-    assert config.get_allow_insecure_read(True) is True
-    assert config.get_allow_insecure_read(False) is False
-    assert config.get_allow_insecure_read(None) is False
+    assert config.get_allow_pickle_read(True) is True
+    assert config.get_allow_pickle_read(False) is False
+    assert config.get_allow_pickle_read(None) is False

--- a/pins/tests/test_config.py
+++ b/pins/tests/test_config.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+from pins.tests.helpers import rm_env
+from pins import config
+
+
+@pytest.fixture
+def env_unset():
+    with rm_env(
+        config.PINS_ENV_DATA_DIR,
+        config.PINS_ENV_CACHE_DIR,
+        config.PINS_ENV_INSECURE_READ,
+    ):
+        yield
+
+
+def test_allow_insecure_read_no_env(env_unset):
+    assert config.get_allow_insecure_read(True) is True
+    assert config.get_allow_insecure_read(False) is False
+
+
+def test_allow_insecure_read_env_1(env_unset):
+    os.environ[config.PINS_ENV_INSECURE_READ] = "1"
+
+    assert config.get_allow_insecure_read(True) is True
+    assert config.get_allow_insecure_read(False) is False
+    assert config.get_allow_insecure_read(None) is True
+
+
+def test_allow_insecure_read_env_0(env_unset):
+    os.environ[config.PINS_ENV_INSECURE_READ] = "0"
+
+    assert config.get_allow_insecure_read(True) is True
+    assert config.get_allow_insecure_read(False) is False
+    assert config.get_allow_insecure_read(None) is False


### PR DESCRIPTION
Addresses #39 by requiring users to set one of the following (ordered highest to lowest priority):

* allow_insecure_read=True when initializing the board
* the PINS_ALLOW_INSECURE_READ=1 environment variable

TODO:

* document in getting started / the board docstring
* add to board constructors