### PR TITLE
Feat cache touch

### DIFF
--- a/pins/__init__.py
+++ b/pins/__init__.py
@@ -11,3 +11,4 @@ del _v
 # Imports ----
 from .boards import BaseBoard
 from .constructors import *
+from .cache import PinsCache, PinsUrlCache

--- a/pins/__init__.py
+++ b/pins/__init__.py
@@ -11,4 +11,4 @@ del _v
 # Imports ----
 from .boards import BaseBoard
 from .constructors import *
-from .cache import PinsCache, PinsUrlCache
+from .cache import PinsCache, PinsUrlCache, cache_prune

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -1,3 +1,4 @@
+import logging
 import tempfile
 import shutil
 import inspect
@@ -390,9 +391,9 @@ class BaseBoard:
         # TODO(question): how to pin_inform? Log or warning?
         if to_delete:
             str_vers = ", ".join([v.version for v in to_delete])
-            print(f"Deleting versions: {str_vers}.")
+            logging.info(f"Deleting versions: {str_vers}.")
         if not to_delete:
-            print("No old versions to delete")
+            logging.info("No old versions to delete")
 
         for version in to_delete:
             self.pin_version_delete(name, version.version)

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -717,12 +717,13 @@ class BoardRsConnect(BaseBoard):
 
         paged_res = self.fs.api.misc_get_applications("content_type:pin", search=search)
         results = paged_res.results
-        names = [f"{cont['owner_username']}/{cont['name']}" for cont in results]
 
         res = []
-        for pin_name in names:
+        for content in results:
+            pin_name = f"{content['owner_username']}/{content['name']}"
+            version = str(content["bundle_id"])
             try:
-                meta = self.pin_meta(pin_name)
+                meta = self.pin_meta(pin_name, version)
                 res.append(meta)
 
             except RsConnectApiRequestError as e:

--- a/pins/cache.py
+++ b/pins/cache.py
@@ -16,7 +16,7 @@ PLACEHOLDER_VERSION = "v"
 PLACEHOLDER_FILE = "file"
 
 
-def touch_access_time(path, access_time: "float | None" = None):
+def touch_access_time(path, access_time: "float | None" = None, strict=True):
     """Update access time of file.
 
     Returns the new access time.
@@ -27,7 +27,7 @@ def touch_access_time(path, access_time: "float | None" = None):
 
     p = Path(path)
 
-    if not p.exists():
+    if not p.exists() and not strict:
         p.touch()
 
     stat = p.stat()
@@ -64,6 +64,7 @@ class PinsCache(SimpleCacheFileSystem):
         # note that this is called in ._open(), at the point it's known the file
         # will be cached
         fn = super()._make_local_details(path)
+        print(f"cache file: {fn}")
         Path(fn).parent.mkdir(parents=True, exist_ok=True)
 
         return fn
@@ -72,7 +73,7 @@ class PinsCache(SimpleCacheFileSystem):
         # the main change in this function is that, for same_name, it returns
         # the full path
         if same_name:
-            if self.hash_prefix:
+            if self.hash_prefix is not None:
                 # optionally make the name relative to a parent path
                 # using the hash of parent path as a prefix, to flatten a bit
                 suffix = Path(path).relative_to(Path(self.hash_prefix))
@@ -87,10 +88,37 @@ class PinsCache(SimpleCacheFileSystem):
 
             return path
         else:
-            return hash_name(path, same_name)
+            raise NotImplementedError()
 
-    def touch_access_time(path):
-        return touch_access_time(path)
+
+class PinsRscCache(PinsCache):
+    """Modifies the PinsCache to allow hash_prefix to be an RSC server url.
+
+    Note that this class also modifies the first / in a path to be a -, so that
+    pin contents will not be put into subdirectories, for e.g. michael/mtcars/data.txt.
+    """
+
+    protocol = "pinsrsccache"
+
+    def hash_name(self, path, same_name):
+        # the main change in this function is that, for same_name, it returns
+        # the full path
+        if same_name:
+            if self.hash_prefix is None:
+                raise NotImplementedError()
+
+            # change pin path of form <user>/<content> to <user>+<content>
+            suffix = path.replace("/", "+", 1)
+            prefix = hash_name(self.hash_prefix, False)
+
+            # TODO: hacky to automatically tack on protocol here
+            # but this is what R pins boards do. Could make a bool arg?
+            proto_name = protocol_to_string(self.fs.protocol)
+            full_prefix = "_".join([proto_name, prefix])
+            return str(full_prefix / Path(suffix))
+
+        else:
+            raise NotImplementedError()
 
 
 class PinsUrlCache(PinsCache):

--- a/pins/cache.py
+++ b/pins/cache.py
@@ -1,4 +1,5 @@
 import humanize
+import logging
 import os
 import time
 import shutil
@@ -64,7 +65,7 @@ class PinsCache(SimpleCacheFileSystem):
         # note that this is called in ._open(), at the point it's known the file
         # will be cached
         fn = super()._make_local_details(path)
-        print(f"cache file: {fn}")
+        logging.info(f"cache file: {fn}")
         Path(fn).parent.mkdir(parents=True, exist_ok=True)
 
         return fn
@@ -199,7 +200,7 @@ class CachePruner:
             for path in to_prune:
                 delete_version(to_prune)
 
-        print("Skipping cache deletion")
+        logging.info("Skipping cache deletion")
 
 
 def delete_version(path: "str | Path"):
@@ -212,7 +213,7 @@ def disk_usage(path):
 
 
 def prompt_cache_prune(to_prune, size) -> bool:
-    print(to_prune)
+    logging.info(f"Pruning items: {to_prune}")
     human_size = humanize.naturalsize(size, binary=True)
     resp = input(f"Delete {len(to_prune)} pin versions, freeing {human_size}?")
     return resp == "yes"

--- a/pins/config.py
+++ b/pins/config.py
@@ -29,3 +29,12 @@ def get_allow_pickle_read(flag):
         flag = bool(env_int)
 
     return flag
+
+
+def _enable_logs():
+    import logging
+
+    format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    handlers = [logging.FileHandler("filename.log"), logging.StreamHandler()]
+
+    logging.basicConfig(level=logging.INFO, format=format, handlers=handlers)

--- a/pins/meta.py
+++ b/pins/meta.py
@@ -112,8 +112,8 @@ class Meta:
 class MetaV0:
     file: Union[str, Sequence[str]]
     type: str
+    description: "str | None"
 
-    description: str
     name: str
 
     version: VersionRaw
@@ -134,9 +134,10 @@ class MetaV0:
     @classmethod
     def from_pin_dict(cls, data, pin_name, version) -> "MetaV0":
         # could infer from dataclasses.fields(), but seems excessive.
-        req_fields = {"type", "description", "name"}
+        req_fields = {"type", "description"}
 
-        req_inputs = {k: v for k, v in data.items() if k in req_fields}
+        # Note that we need to .get(), since fields may not be in metadata
+        req_inputs = {k: data.get(k) for k in req_fields}
         req_inputs["file"] = data["path"]
 
         return cls(**req_inputs, name=pin_name, original_fields=data, version=version)

--- a/pins/rsconnect/api.py
+++ b/pins/rsconnect/api.py
@@ -222,6 +222,7 @@ class RsConnectApi:
 
         headers = self._get_headers()
 
+        logging.info(f"RSConnect API {method}: {url} -- {kwargs}")
         r = self.session.request(method, url, headers=headers, **kwargs)
 
         if return_request:
@@ -247,7 +248,6 @@ class RsConnectApi:
         all_results.extend(data["results"])
 
         while data["results"]:
-            logging.info(f"RSConnect API {method}: {endpoint}")
             page_kwargs = {"page_number": data["current_page"] + 1}
             new_params = {**params, **page_kwargs}
             data = f_query(endpoint, method, params=new_params)

--- a/pins/rsconnect/api.py
+++ b/pins/rsconnect/api.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import requests
 import tempfile
@@ -246,13 +247,12 @@ class RsConnectApi:
         all_results.extend(data["results"])
 
         while data["results"]:
-            print("FETCHING")
+            logging.info(f"RSConnect API {method}: {endpoint}")
             page_kwargs = {"page_number": data["current_page"] + 1}
             new_params = {**params, **page_kwargs}
             data = f_query(endpoint, method, params=new_params)
 
             all_results.extend(data["results"])
-            print(data["results"])
 
         return all_results
 

--- a/pins/tests/test_boards.py
+++ b/pins/tests/test_boards.py
@@ -11,6 +11,7 @@ from pins.meta import MetaRaw
 
 from datetime import datetime, timedelta
 from time import sleep
+from pathlib import Path
 
 # using pytest cases, so that we can pass in fixtures as parameters
 # TODO: this seems like maybe overkill
@@ -286,6 +287,36 @@ def test_board_pin_search_name(board, df, search, matches):
     metas = board.pin_search(search, as_df=False)
     sorted_meta_names = sorted([m.name for m in metas])
     assert sorted_meta_names == sorted(matches)
+
+
+# BaseBoard specific ==========================================================
+
+from pins.boards import BaseBoard  # noqa
+from pins.cache import PinsCache  # noqa
+
+
+def test_board_base_pin_meta_cache_touch(tmp_dir2, df):
+
+    cache = fsspec.filesystem(
+        "pinscache", target_protocol="file", same_names=True, hash_prefix=str(tmp_dir2),
+    )
+    board = BaseBoard(str(tmp_dir2), fs=cache)
+
+    board.pin_write(df, "some_df", type="csv")
+    meta = board.pin_meta("some_df")
+    v = meta.version.version
+
+    p_cache_version = board._get_cache_path(meta.name, v)
+    p_cache_meta = Path(p_cache_version) / "data.txt"
+
+    orig_access = p_cache_meta.stat().st_atime
+
+    board.pin_meta("some_df")
+
+    new_access = p_cache_meta.stat().st_atime
+
+    assert orig_access < new_access
+    assert False
 
 
 # RStudio Connect specific ====================================================

--- a/pins/tests/test_boards.py
+++ b/pins/tests/test_boards.py
@@ -316,7 +316,6 @@ def test_board_base_pin_meta_cache_touch(tmp_dir2, df):
     new_access = p_cache_meta.stat().st_atime
 
     assert orig_access < new_access
-    assert False
 
 
 # RStudio Connect specific ====================================================


### PR DESCRIPTION
Addresses #75 by updating the access time of a pin's `data.txt` every time it is accessed.
Additional changes:

* replaced print statements with logging (put in `pins.config._enable_logs()` to print logs for now)
* added an RSC specific cache class (fixes user names creating unnecessary nesting in the cache)
