### PR TITLE
feat: generalize automatic titles

### DIFF
--- a/pins/boards.py
+++ b/pins/boards.py
@@ -531,7 +531,7 @@ class BaseBoard:
             raise NotImplementedError("Type argument is required.")
 
         if title is None:
-            title = default_title(x, type)
+            title = default_title(x, name)
 
         # create metadata from object on disk ---------------------------------
         # save all pin data to a temporary folder (including data.txt), so we

--- a/pins/drivers.py
+++ b/pins/drivers.py
@@ -1,5 +1,3 @@
-import builtins
-
 from pathlib import Path
 
 from .config import get_allow_pickle_read, PINS_ENV_INSECURE_READ
@@ -119,17 +117,14 @@ def save_data(
     return fname
 
 
-def default_title(obj, type):
-    if type == "csv":
-        import pandas as pd
+def default_title(obj, name):
+    import pandas as pd
 
-        if isinstance(obj, pd.DataFrame):
-            # TODO(compat): title says CSV rather than data.frame
-            # see https://github.com/machow/pins-python/issues/5
-            shape_str = " x ".join(map(str, obj.shape))
-            return f"A pinned {shape_str} CSV"
-        raise NotImplementedError(
-            f"No default csv title support for class: {builtins.type(obj)}"
-        )
-
-    raise NotImplementedError(f"Cannot create default title for type: {type}")
+    if isinstance(obj, pd.DataFrame):
+        # TODO(compat): title says CSV rather than data.frame
+        # see https://github.com/machow/pins-python/issues/5
+        shape_str = " x ".join(map(str, obj.shape))
+        return f"{name}: a pinned {shape_str} DataFrame"
+    else:
+        obj_name = type(obj).__qualname__
+        return f"{name}: a pinned {obj_name} object"

--- a/pins/tests/test_boards.py
+++ b/pins/tests/test_boards.py
@@ -38,7 +38,7 @@ def test_board_pin_write_default_title(board):
 
     df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
     meta = board.pin_write(df, "df_csv", title=None, type="csv")
-    assert meta.title == "A pinned 3 x 2 CSV"
+    assert meta.title == "df_csv: a pinned 3 x 2 DataFrame"
 
 
 def test_board_pin_write_prepare_pin(board, tmp_dir2):

--- a/pins/tests/test_drivers.py
+++ b/pins/tests/test_drivers.py
@@ -1,5 +1,6 @@
 import fsspec
 import pytest
+import pandas as pd
 
 from pathlib import Path
 
@@ -7,7 +8,7 @@ from pins.tests.helpers import rm_env
 
 from pins.meta import MetaRaw
 from pins.config import PINS_ENV_INSECURE_READ
-from pins.drivers import load_data, save_data
+from pins.drivers import load_data, save_data, default_title
 from pins.errors import PinsInsecureReadError
 
 
@@ -19,6 +20,29 @@ def some_joblib(tmp_dir2):
     joblib.dump({"a": 1}, p_obj)
 
     return p_obj
+
+
+# default title ---------------------------------------------------------------
+
+
+class ExC:
+    class D:
+        pass
+
+
+@pytest.mark.parametrize(
+    "obj, dst_title",
+    [
+        (pd.DataFrame({"x": [1, 2]}), "somename: a pinned 2 x 1 DataFrame"),
+        (pd.DataFrame({"x": [1], "y": [2]}), "somename: a pinned 1 x 2 DataFrame"),
+        (ExC(), "somename: a pinned ExC object"),
+        (ExC().D(), "somename: a pinned ExC.D object"),
+        ([1, 2, 3], "somename: a pinned list object"),
+    ],
+)
+def test_default_title(obj, dst_title):
+    res = default_title(obj, "somename")
+    assert res == dst_title
 
 
 def test_driver_roundtrip_csv(tmp_dir2):


### PR DESCRIPTION
Addresses #88, #5 , by using an objects `__qualname__` if it is not a pandas DataFrame. Note that I also fixed the title structure to match R pins: `"<pin_name>: a pinned {more info} {obj_name}"`