### PR TITLE
feat: deparse rsc and file boards

### DIFF
--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -11,6 +11,51 @@ class DEFAULT:
     pass
 
 
+# Representing constructors ===================================================
+
+
+def deparse_board(board: BaseBoard):
+    """Return a representation of how a board could be reconstructed.
+
+    Note that this function does not try to represent the exact arguments used
+    to construct a board, but key pieces (like the path to the board). You may
+    need to specify environment variables with API keys to complete the connection.
+
+    Parameters
+    ----------
+    board:
+        A pins board to be represented.
+
+    Examples
+    --------
+
+    The example below deparses a board connected to RStudio Connect.
+
+    >>> deparse_board(board_rsconnect(server_url="http://example.com", api_key="xxx"))
+    "board_rsconnect(server_url='http://example.com')"
+
+    Note that the deparsing an RStudio Connect board does not keep the api_key,
+    which is sensitive information. In this case, you can set the CONNECT_API_KEY
+    environment variable to connect.
+
+    Below is an example of representing a board connected to a local folder.
+
+    >>> deparse_board(board_folder("a/b/c"))
+    "board_folder('a/b/c')"
+    """
+
+    prot = board.fs.protocol
+    if prot == "rsc":
+        url = board.fs.api.server_url
+        return f"board_rsconnect(server_url={repr(url)})"
+    elif prot == "file":
+        return f"board_folder({repr(board.board)})"
+    else:
+        raise NotImplementedError(
+            "board deparsing currently not supported for protocol: {prot}"
+        )
+
+
 # Board constructors ==========================================================
 # note that libraries not used by board classes above are imported within these
 # functions. may be worth moving these funcs into their own module.

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -13,8 +13,8 @@ class DEFAULT:
 
 # Representing constructors ===================================================
 
-
-def deparse_board(board: BaseBoard):
+# Note that this is not a constructor, but a function to represent them.
+def board_deparse(board: BaseBoard):
     """Return a representation of how a board could be reconstructed.
 
     Note that this function does not try to represent the exact arguments used
@@ -31,7 +31,7 @@ def deparse_board(board: BaseBoard):
 
     The example below deparses a board connected to RStudio Connect.
 
-    >>> deparse_board(board_rsconnect(server_url="http://example.com", api_key="xxx"))
+    >>> board_deparse(board_rsconnect(server_url="http://example.com", api_key="xxx"))
     "board_rsconnect(server_url='http://example.com')"
 
     Note that the deparsing an RStudio Connect board does not keep the api_key,
@@ -40,7 +40,7 @@ def deparse_board(board: BaseBoard):
 
     Below is an example of representing a board connected to a local folder.
 
-    >>> deparse_board(board_folder("a/b/c"))
+    >>> board_deparse(board_folder("a/b/c"))
     "board_folder('a/b/c')"
     """
 

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -188,3 +188,20 @@ def test_board_constructor_folder(tmp_dir2, df):
     df2 = board.pin_read("some_df")
 
     assert df.equals(df2)
+
+
+# Deparsing ===================================================================
+
+
+def test_board_deparse(board):
+    prot = board.fs.protocol
+    if prot not in ["rsc", "file"]:
+        # not implemented for other boards
+        pytest.xfail()
+
+    with rm_env("CONNECT_API_KEY"):
+        if prot == "rsc":
+            os.environ["CONNECT_API_KEY"] = board.fs.api.api_key
+
+        new_board = eval(c.deparse_board(board), c.__dict__)
+        new_board.pin_list()

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -203,5 +203,5 @@ def test_board_deparse(board):
         if prot == "rsc":
             os.environ["CONNECT_API_KEY"] = board.fs.api.api_key
 
-        new_board = eval(c.deparse_board(board), c.__dict__)
+        new_board = eval(c.board_deparse(board), c.__dict__)
         new_board.pin_list()


### PR DESCRIPTION
Addresses #89, e.g.

```python
>>> from pins.constructors import *
>>> board_deparse(board_rsconnect(server_url="http://example.com", api_key="xxx"))
"board_rsconnect(server_url='http://example.com')"

>>> board_deparse(board_folder("a/b/c"))
"board_folder('a/b/c')"
```

Note that currently the RSC approach differs from R:

```R
> board_deparse(board)
board_rsconnect("envvar", server = "https://colorado.rstudio.com/rsc")
```

Let's remedy in #93 