### PR TITLE
ci: test across py 3.7 to 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      python: ["3.7", "3.8", "3.9", "3.10"]
       matrix:
         include:
           - os: "macos-latest"
@@ -26,12 +27,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements/dev.txt
-          python -m pip install -e .
+          python -m pip install .[test]
       - name: Run tests
         run: |
           pytest pins -m 'not fs_rsc and not skip_on_github' $PYTEST_OPTS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[test]
+          python -m pip install -e .[test]
       - name: Run tests
         run: |
           pytest pins -m 'not fs_rsc and not skip_on_github' $PYTEST_OPTS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.7", "3.8", "3.9", "3.10"]
+        os: ["ubuntu-latest"]
+        pytest_ops: [""]
         include:
           - os: "macos-latest"
+            python: "3.10"
             # ignore doctests, as they involve calls to github, and all mac machines
             # use the same IP address
             pytest_opts: "-k pins/tests"
-          - os: "ubuntu-latest"
-            pytest_opts:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      python: ["3.7", "3.8", "3.9", "3.10"]
       matrix:
+        python: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - os: "macos-latest"
             # ignore doctests, as they involve calls to github, and all mac machines

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ docs-clean:
 requirements/dev.txt: setup.cfg
 	@# allows you to do this...
 	@# make requirements | tee > requirements/some_file.txt
-	@pip-compile setup.cfg --rebuild --extra dev --output-file=- > $@
+	@pip-compile setup.cfg --rebuild --extra doc --extra test --output-file=- > $@
 
-binder/requirements.txt: setup.cfg
-	@pip-compile setup.cfg --rebuild --extra dev --output-file=- > $@
+binder/requirements.txt: requirements/dev.txt
+	cp $< $@

--- a/pins/__init__.py
+++ b/pins/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
 # Set version ----
-from importlib.metadata import version as _v
+from importlib_metadata import version as _v
 
 __version__ = _v("pins")
 

--- a/pins/tests/test_cache.py
+++ b/pins/tests/test_cache.py
@@ -1,5 +1,4 @@
 import time
-import shutil
 
 import pytest
 from pins.cache import (
@@ -72,7 +71,7 @@ def test_pins_cache_open():
 
 @pytest.fixture
 def a_cache(tmp_dir2):
-    return tmp_dir2
+    return tmp_dir2 / "board_cache"
 
 
 def create_metadata(p, access_time):
@@ -141,12 +140,10 @@ def test_cache_pruner_old_versions_multi_pins(a_cache, pin1_v2, pin2_v3):
     assert set(old) == {pin1_v2, pin2_v3}
 
 
-def test_cache_prune_prompt(tmp_dir2, a_cache, pin1_v1, pin2_v3, monkeypatch):
-    p_board = tmp_dir2 / "a_board"
-    shutil.copytree(a_cache, p_board)
-    cache_prune(days=1, cache_root=tmp_dir2, prompt=False)
+def test_cache_prune_prompt(a_cache, pin1_v1, pin2_v3, monkeypatch):
+    cache_prune(days=1, cache_root=a_cache.parent, prompt=False)
 
-    versions = list(p_board.glob("*/*"))
+    versions = list(a_cache.glob("*/*"))
 
     # pin2_v3 deleted
     assert len(versions) == 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ author_email = mc_al_github@fastmail.com
 license = MIT
 keywords = data, tidyverse
 classifiers =
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -20,7 +21,7 @@ packages = find:
 include_package_data = True
 zipsafe = False
 
-python_requires = >3.8
+python_requires = >=3.7
 install_requires =
     fsspec
     pyyaml
@@ -28,9 +29,9 @@ install_requires =
     pandas
     jinja2
     joblib
+    importlib-metadata
     importlib-resources
     appdirs
-    siuba
     humanize
 
 
@@ -40,18 +41,18 @@ aws =
 azure =
     adlfs
 
-dev =
+doc =
+    sphinx
+    jupytext
+    jupyter-book
+
+test =
     pip-tools
-    pydata-sphinx-theme
     pytest
     pytest-cases
     pytest-dotenv
-    sphinx
     s3fs
-    jupytext
-    jupyter-book
-    nbsphinx
-    ipykernel
+    adlfs
 
 
 [bdist_wheel]


### PR DESCRIPTION
* handle some backward incompatible pieces (e.g. Protocol, shutils.copytree)
* add python versions to test matrix
* note that I removed installing dev.txt requirements, so CI now checks "would a person installing pins right now be able to do these things"