### PR TITLE
Feat rsc access type

### DIFF
--- a/pins/__init__.py
+++ b/pins/__init__.py
@@ -20,4 +20,5 @@ from .constructors import (
     board_urls,
     board_rsconnect,
     board_s3,
+    board,
 )

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -15,7 +15,7 @@ from .versions import VersionRaw, guess_version
 from .meta import Meta, MetaRaw, MetaFactory
 from .errors import PinsError
 from .drivers import load_data, save_data, default_title
-from .utils import inform
+from .utils import inform, ExtendMethodDoc
 from .config import get_allow_rsc_short_name
 
 
@@ -732,7 +732,15 @@ class BoardRsConnect(BaseBoard):
         names = [f"{cont['owner_username']}/{cont['name']}" for cont in results]
         return names
 
-    def pin_write(self, *args, **kwargs):
+    @ExtendMethodDoc
+    def pin_write(self, *args, access_type=None, **kwargs):
+        """Write a pin.
+
+        Extends parent method in the following ways:
+
+        * Modifies content item to include any title and description changes.
+        * Adds access_type argument to specify who can see content. Defaults to "acl".
+        """
 
         # run parent function ---
 
@@ -757,6 +765,7 @@ class BoardRsConnect(BaseBoard):
 
         return meta
 
+    @ExtendMethodDoc
     def pin_search(self, search=None, as_df=True):
         from pins.rsconnect.api import RsConnectApiRequestError
 
@@ -793,6 +802,7 @@ class BoardRsConnect(BaseBoard):
 
         return res
 
+    @ExtendMethodDoc
     def pin_version_delete(self, *args, **kwargs):
         from pins.rsconnect.api import RsConnectApiRequestError
 
@@ -804,6 +814,7 @@ class BoardRsConnect(BaseBoard):
 
             raise PinsError("RStudio Connect cannot delete the latest pin version.")
 
+    @ExtendMethodDoc
     def pin_versions_prune(self, *args, **kwargs):
         sig = inspect.signature(super().pin_versions_prune)
         if sig.bind(*args, **kwargs).arguments.get("days") is not None:

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -650,12 +650,15 @@ class BoardManual(BaseBoard):
 
     #    return super().pin_read(*args, **kwargs)
 
+    @ExtendMethodDoc
     def pin_list(self):
         return list(self.pin_paths)
 
+    @ExtendMethodDoc
     def pin_versions(self, *args, **kwargs):
         raise NotImplementedError("This board does not support pin_versions.")
 
+    @ExtendMethodDoc
     def pin_meta(self, name, version=None):
         if version is not None:
             raise NotImplementedError()
@@ -680,6 +683,7 @@ class BoardManual(BaseBoard):
 
         return meta
 
+    @ExtendMethodDoc
     def pin_download(self, name, version=None, hash=None) -> Sequence[str]:
         meta = self.pin_meta(name, version)
 
@@ -723,6 +727,7 @@ class BoardRsConnect(BaseBoard):
 
     # defaults work ----
 
+    @ExtendMethodDoc
     def pin_list(self):
         # lists all pin content on RStudio Connect server
         # we can't use fs.ls, because it will list *all content*

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -70,7 +70,11 @@ def board(
     storage_options: "dict | None" = None,
     board_factory: "callable | BaseBoard | None" = None,
 ):
-    """
+    """General function for constructing a pins board.
+
+    Note that this is a lower-level function. For most use cases, use a more specific
+    function like board_local(...), or board_s3(...).
+
     Parameters
     ----------
     protocol:

--- a/pins/rsconnect/api.py
+++ b/pins/rsconnect/api.py
@@ -304,7 +304,7 @@ class RsConnectApi:
         return Content(result)
 
     def post_content_item(
-        self, name, access_type, title: str = "", description: str = "", **kwargs
+        self, name, access_type: str, title: str = "", description: str = "", **kwargs
     ) -> Content:
         data = self._get_params(locals(), exclude={"kwargs"})
         result = self.query_v1("content", "POST", json={**data, **kwargs})

--- a/pins/tests/test_rsconnect_api.py
+++ b/pins/tests/test_rsconnect_api.py
@@ -426,6 +426,25 @@ def test_rsconnect_fs_put_bundle(fs_short):
     assert f_index.read().decode() == (Path(path_to_example) / "index.html").read_text()
 
 
+def test_rsconnect_fs_put_bundle_all_access(fs_short):
+    import requests
+
+    # TODO: use pkg_resources to get this
+    path_to_example = "pins/tests/example-bundle"
+    fs_short.put(
+        path_to_example, "susan/test-content", recursive=True, access_type="all"
+    )
+
+    # access control is set at the content (not bundle) level. we need to get the
+    # content guid to recreate the "shareable" link
+    content = fs_short.info("susan/test-content")
+
+    r = requests.get(f"{fs_short.api.server_url}/content/{content['guid']}")
+    r.raise_for_status()
+
+    assert r.text == (Path(path_to_example) / "index.html").read_text()
+
+
 # fs.mkdir ----
 
 

--- a/pins/utils.py
+++ b/pins/utils.py
@@ -1,5 +1,8 @@
 import sys
 
+from functools import update_wrapper
+from types import MethodType
+
 from .config import pins_options
 
 
@@ -12,16 +15,23 @@ def inform(log, msg):
 
 
 class ExtendMethodDoc:
+    # Note that the indentation assumes these are top-level method docstrings,
+    # so are indented 8 spaces (after the initial sentence).
     template = """\
 {current_doc}
 
-Parent method documentation:
+        Parent method documentation:
 
-{parent_doc}
-"""
+        {parent_doc}
+        """
 
     def __init__(self, func):
         self.func = func
+
+        # allows sphinx to add the method signature to the docs
+        # this is pretty benign, since it's very hard to call a descriptor
+        # after class initialization (where __set_name__ is called).
+        self.__call__ = func
 
     def __set_name__(self, owner, name):
         bound_parent_meth = getattr(super(owner, owner), name)
@@ -29,13 +39,27 @@ Parent method documentation:
         self._parent_doc = bound_parent_meth.__doc__
         self._orig_doc = self.func.__doc__
 
-        self.func.__doc__ = self.template.format(
-            current_doc=self._orig_doc, parent_doc=self._parent_doc
+        if self._orig_doc is not None:
+            # update the docstring of the subclass method to include parent doc.
+            self.func.__doc__ = self.template.format(
+                current_doc=self._orig_doc, parent_doc=self._parent_doc
+            )
+
+        # make descriptor look like wrapped function
+        update_wrapper(
+            self, self.func, ("__doc__", "__name__", "__module__", "__qualname__")
         )
-        self.__doc__ = self.func.__doc__
 
     def __get__(self, obj, objtype=None):
         if obj is None:
+            # accessing from class, return descriptor itself.
             return self
 
-        return self.func
+        # accessing from instance
+        return MethodType(self.func, obj)
+
+    def __call__(self, *args, **kwargs):
+        # this is defined, so that callable(ExtendMethodDoc(...)) is True,
+        # which allows all the inspect machinery to give sphinx the __call__
+        # attribute we set in __init__.
+        raise NotImplementedError()

--- a/pins/utils.py
+++ b/pins/utils.py
@@ -9,3 +9,33 @@ def inform(log, msg):
 
     if not pins_options.quiet:
         print(msg, file=sys.stderr)
+
+
+class ExtendMethodDoc:
+    template = """\
+{current_doc}
+
+Parent method documentation:
+
+{parent_doc}
+"""
+
+    def __init__(self, func):
+        self.func = func
+
+    def __set_name__(self, owner, name):
+        bound_parent_meth = getattr(super(owner, owner), name)
+
+        self._parent_doc = bound_parent_meth.__doc__
+        self._orig_doc = self.func.__doc__
+
+        self.func.__doc__ = self.template.format(
+            current_doc=self._orig_doc, parent_doc=self._parent_doc
+        )
+        self.__doc__ = self.func.__doc__
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+
+        return self.func


### PR DESCRIPTION
Addresses:

* #67 
* Adds ExtendMethodDoc to ensure that child methods include parent docstrings (e.g. a person using `pin_read` will want the full docstring, even if they're using `BoardRsConnect`.